### PR TITLE
Create user attributes

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,12 @@
+class RegistrationsController < Devise::RegistrationsController
+
+  private
+
+  def sign_up_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+  end
+
+  def account_update_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :current_password)
+  end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,6 +21,16 @@
     <%= f.password_field :password_confirmation, autocomplete: "off" %>
   </div>
 
+  <div class="field">
+    <%= f.label :first_name %><br />
+    <%= f.text_field :first_name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :last_name %><br />
+    <%= f.text_field :last_name %>
+  </div>
+
   <div class="actions">
     <%= f.submit "Sign up" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root 'groups#index'
-  devise_for :users
+  devise_for :users, :controllers => {registrations: 'registrations' }
 
   resources :groups, only: [:index]
 end

--- a/db/migrate/20150606180758_add_attributes_to_users.rb
+++ b/db/migrate/20150606180758_add_attributes_to_users.rb
@@ -1,0 +1,6 @@
+class AddAttributesToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :first_name, :string, null: false
+    add_column :users, :last_name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150606172955) do
+ActiveRecord::Schema.define(version: 20150606180758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,8 @@ ActiveRecord::Schema.define(version: 20150606172955) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.string   "first_name",                          null: false
+    t.string   "last_name",                           null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -18,6 +18,10 @@ feature 'user registers', %Q{
     fill_in 'Email', with: 'john@example.com'
     fill_in 'Password', with: 'password'
     fill_in 'Password confirmation', with: 'password'
+    fill_in 'First name', with: 'Joe'
+    fill_in 'Last name', with: 'Shmoe'
+
+    save_and_open_page
 
     click_button 'Sign up'
 

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -3,6 +3,8 @@ require 'factory_girl'
 FactoryGirl.define do
   factory :user do
     sequence(:email) {|n| "user#{n}@example.com" }
+    first_name 'Joe'
+    last_name 'Shmoe'
     password 'password'
     password_confirmation 'password'
   end


### PR DESCRIPTION
This PR adds the first and last name as required fields when a new user signs up. It also extends Devises functionality to make sure the first and last name are used when creating a new user. 
